### PR TITLE
recalculate button should dump vm instructions and profile nodes reliably.

### DIFF
--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -90,8 +90,10 @@
                 Width="100"
                 Height="24"
                 Margin="3"
+                IsEnabled="{Binding  Path=IsRecomputeEnabled}"
                 Click="RecomputeGraph_Click">
                 Recompute All
+               
             </Button>
         </StackPanel>
         

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -169,11 +169,14 @@ namespace TuneUp
         {
 
 
-            // Enable profiling
+            //put the graph into manual mode as there is no guarantee that nodes will be marked dirty in topologically sorted oreder.
+            //during a reset.
             CurrentWorkspace.RunSettings.RunType = Dynamo.Models.RunType.Manual;
-            //TODO need a way to do this from an extension and not cause a run.//VM utilities?
+            //TODO need a way to do this from an extension and not cause a run.//DynamoModel interface or a more specific reset command.
             (viewLoadedParams.DynamoWindow.DataContext as DynamoViewModel).Model.ResetEngine(true);
+            // Enable profiling on the new engine controller after the reset.
             CurrentWorkspace.EngineController.EnableProfiling(true, currentWorkspace,currentWorkspace.Nodes);
+            //run the graph now that profiling is enabled.
             CurrentWorkspace.Run();
 
             profilingEnabled = true;

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -170,12 +170,11 @@ namespace TuneUp
 
 
             // Enable profiling
-            var currentWorkspace = (viewLoadedParams.CurrentWorkspaceModel as HomeWorkspaceModel);
-            currentWorkspace.RunSettings.RunType = Dynamo.Models.RunType.Manual;
+            CurrentWorkspace.RunSettings.RunType = Dynamo.Models.RunType.Manual;
             //TODO need a way to do this from an extension and not cause a run.//VM utilities?
             (viewLoadedParams.DynamoWindow.DataContext as DynamoViewModel).Model.ResetEngine(true);
-            (viewLoadedParams.DynamoWindow.DataContext as DynamoViewModel).Model.EngineController.EnableProfiling(true, currentWorkspace,currentWorkspace.Nodes);
-            ((viewLoadedParams.DynamoWindow.DataContext as DynamoViewModel).Model.CurrentWorkspace as HomeWorkspaceModel).Run();
+            CurrentWorkspace.EngineController.EnableProfiling(true, currentWorkspace,currentWorkspace.Nodes);
+            CurrentWorkspace.Run();
 
             profilingEnabled = true;
             executionTimeData = CurrentWorkspace.EngineController.ExecutionTimeData;

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Data;
 using Dynamo.Core;
 using Dynamo.Engine.Profiling;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
+using Dynamo.ViewModels;
 using Dynamo.Wpf.Extensions;
-using System.Collections.ObjectModel;
-using System.Windows.Data;
-using System.ComponentModel;
 
 namespace TuneUp
 {
@@ -48,8 +49,8 @@ namespace TuneUp
                 {
                     currentWorkspace.NodeAdded -= CurrentWorkspaceModel_NodeAdded;
                     currentWorkspace.NodeRemoved -= CurrentWorkspaceModel_NodeRemoved;
-                    CurrentWorkspace.EvaluationStarted -= CurrentWorkspaceModel_EvaluationStarted;
-                    CurrentWorkspace.EvaluationCompleted -= CurrentWorkspaceModel_EvaluationCompleted;
+                    currentWorkspace.EvaluationStarted -= CurrentWorkspaceModel_EvaluationStarted;
+                    currentWorkspace.EvaluationCompleted -= CurrentWorkspaceModel_EvaluationCompleted;
 
                     foreach (var node in currentWorkspace.Nodes)
                     {
@@ -66,8 +67,8 @@ namespace TuneUp
                 {
                     currentWorkspace.NodeAdded += CurrentWorkspaceModel_NodeAdded;
                     currentWorkspace.NodeRemoved += CurrentWorkspaceModel_NodeRemoved;
-                    CurrentWorkspace.EvaluationStarted += CurrentWorkspaceModel_EvaluationStarted;
-                    CurrentWorkspace.EvaluationCompleted += CurrentWorkspaceModel_EvaluationCompleted;
+                    currentWorkspace.EvaluationStarted += CurrentWorkspaceModel_EvaluationStarted;
+                    currentWorkspace.EvaluationCompleted += CurrentWorkspaceModel_EvaluationCompleted;
 
                     foreach (var node in currentWorkspace.Nodes)
                     {
@@ -81,6 +82,23 @@ namespace TuneUp
 
         #region PublicProperties
 
+        private bool isRecomputeEnabled = true;
+        /// <summary>
+        /// Is the recomputeAll button enabled in the UI. Users should not be able to force a 
+        /// reset of the engine and rexecution of the graph if one is still ongoing. This causes...trouble.
+        /// </summary>
+        public bool IsRecomputeEnabled
+        {
+            get => isRecomputeEnabled;
+            private set
+            {
+                if (isRecomputeEnabled != value)
+                {
+                    isRecomputeEnabled = value;
+                    RaisePropertyChanged(nameof(IsRecomputeEnabled));
+                }
+            }
+        }
         /// <summary>
         /// Collection of profiling data for nodes in the current workspace
         /// </summary>
@@ -114,7 +132,7 @@ namespace TuneUp
         public TuneUpWindowViewModel(ViewLoadedParams p)
         {
             viewLoadedParams = p;
-            
+
             p.CurrentWorkspaceChanged += OnCurrentWorkspaceChanged;
             p.CurrentWorkspaceCleared += OnCurrentWorkspaceCleared;
 
@@ -137,7 +155,7 @@ namespace TuneUp
             {
                 return;
             }
-            
+
             foreach (var node in CurrentWorkspace.Nodes)
             {
                 var profiledNode = new ProfiledNodeViewModel(node);
@@ -149,13 +167,20 @@ namespace TuneUp
 
         internal void ResetProfiling()
         {
-            // Disable profiling
-            CurrentWorkspace.EngineController.EnableProfiling(false, CurrentWorkspace, new List<NodeModel>());
-            
+
+
             // Enable profiling
-            CurrentWorkspace.EngineController.EnableProfiling(true, CurrentWorkspace, CurrentWorkspace.Nodes);
+            var currentWorkspace = (viewLoadedParams.CurrentWorkspaceModel as HomeWorkspaceModel);
+            currentWorkspace.RunSettings.RunType = Dynamo.Models.RunType.Manual;
+            //TODO need a way to do this from an extension and not cause a run.//VM utilities?
+            (viewLoadedParams.DynamoWindow.DataContext as DynamoViewModel).Model.ResetEngine(true);
+            (viewLoadedParams.DynamoWindow.DataContext as DynamoViewModel).Model.EngineController.EnableProfiling(true, currentWorkspace,currentWorkspace.Nodes);
+            ((viewLoadedParams.DynamoWindow.DataContext as DynamoViewModel).Model.CurrentWorkspace as HomeWorkspaceModel).Run();
+
             profilingEnabled = true;
             executionTimeData = CurrentWorkspace.EngineController.ExecutionTimeData;
+
+
         }
 
         internal void EnableProfiling()
@@ -167,7 +192,7 @@ namespace TuneUp
                 profilingEnabled = true;
                 executionTimeData = CurrentWorkspace.EngineController.ExecutionTimeData;
             }
-            
+
             RaisePropertyChanged(nameof(ProfiledNodesCollection));
         }
 
@@ -177,6 +202,7 @@ namespace TuneUp
 
         private void CurrentWorkspaceModel_EvaluationStarted(object sender, EventArgs e)
         {
+            IsRecomputeEnabled = false;
             foreach (var node in nodeDictionary.Values)
             {
                 // Reset Node Execution Order info
@@ -197,6 +223,7 @@ namespace TuneUp
 
         private void CurrentWorkspaceModel_EvaluationCompleted(object sender, Dynamo.Models.EvaluationCompletedEventArgs e)
         {
+            IsRecomputeEnabled = true;
             /*foreach (var node in nodeDictionary.Values)
             {
                 // Update state of any node that is still in the "Executing" state


### PR DESCRIPTION
@scottmitchell 

please incorporate this change into your current most up to date branch.

I also noticed master branch on the main repo is lagging really far behind, from a month ago, lets get this work back into there ASAP.
I wasn't sure what on here you planned to keep for testing / experimentation (executionCount columns?) and what you intended for master.

maybe we can keep these columns for now or add an option to enable/disable them? I think we can discuss that separately from this work.
At the minimum I'd like the recalculation work to get into master first.


![profilingrecalc](https://user-images.githubusercontent.com/508936/67128485-cd80c680-f1c9-11e9-88f1-a5dee45ac35e.gif)

now for the story:

Aparajit and I looked into this for a while, it appears that when the nodes are marked dirty this is not sufficient to clear the older instructions in the VM which are calling the `RecordEnd` functions - then it appears there is a possible interaction with associative update which kicks off extra updates of those functions. The nodes themselves did not seem to execute multiple times but the times were all garbage.

This PR fixes the issue by reseting the VM and clearing instructions before running the graph again, it also puts the graph into manual mode to ensure that nodes are executed in the correct order to avoid multiple runs when marking nodes dirty.



@aparajit-pratap FYI